### PR TITLE
fix(scraping): use get instead of post on the api

### DIFF
--- a/src/routes/api/scrapeNaver/[query]/+server.ts
+++ b/src/routes/api/scrapeNaver/[query]/+server.ts
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { scrapeNaver } from '$lib';
+
+export const GET: RequestHandler = async({ request, params }) => {
+	const queryTerm = params.query;
+	const links = await scrapeNaver(queryTerm);
+
+	return json(links);
+}
+

--- a/src/routes/scrape/+page.ts
+++ b/src/routes/scrape/+page.ts
@@ -3,15 +3,18 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ fetch, url }) => {
 	const searchParams = url.searchParams.get('searchNaverFor');
 
+	/*
 	const response = await fetch('/api/scrapeNaver', {
 		method: 'POST',
 		body: JSON.stringify(searchParams),
 	});
+ */
 
+	const getResponse = await fetch(`/api/scrapeNaver/${searchParams}`)
 
 	return {
 		title: `Links for ${searchParams}`,
-		links: await response.json(),
+		links: await getResponse.json(),
 		searchedFor: searchParams,
 	}
 


### PR DESCRIPTION
In production, keep getting a 500 error that get is not allowed, so I have removed the call to the post api.